### PR TITLE
fix: make optional fields in API response types to handle null values

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,116 @@
+# TODO: Fix Broken Field Serialization Error
+
+## タスクリスト
+
+### 1. コード修正
+- [x] `src/raindrop/types.rs`の`Bookmark`構造体の`broken`フィールドを`Option<bool>`に変更
+- [x] テストケースの更新（types.rs:627行目のアサーション修正）
+- [x] エラーハンドリングの改善（client.rs:57行目付近にデバッグ情報追加）
+
+### 2. テスト
+- [x] 既存のユニットテストが全て通ることを確認（`cargo test`）
+- [x] `broken`フィールドが含まれないJSONのテストケースを追加
+- [x] linterチェック（`cargo clippy`）
+- [x] フォーマットチェック（`cargo fmt --check`）
+
+### 3. 動作確認
+- [x] ビルドが成功することを確認（`cargo build`）
+- [ ] 実際のRaindrop APIに対してget_bookmarksを実行し、エラーが解消されることを確認
+
+### 4. ドキュメント
+- [ ] 変更内容をREADMEに記載（必要に応じて）
+- [ ] コミットメッセージの準備
+
+### 5. 完了
+- [ ] 全てのタスクが完了したことを確認
+- [ ] プルリクエストの作成
+
+## 進捗メモ
+- 開始時刻: 2025-07-21
+- ブランチ名: `fix/broken-field-serialization-error`
+
+---
+
+# TODO: Fix FullName Field Serialization Error
+
+## タスクリスト
+
+### 1. コード修正
+- [x] `src/raindrop/types.rs`の`CreatorRef`構造体の`full_name`フィールドを`Option<String>`に変更
+- [x] テストケースで`CreatorRef`を使用している箇所の確認と必要に応じた修正
+
+### 2. テスト
+- [x] `fullName`フィールドが含まれないコレクションのテストケースを追加
+- [x] 既存のユニットテストが全て通ることを確認（`cargo test`）
+- [x] linterチェック（`cargo clippy`）
+- [x] フォーマットチェック（`cargo fmt --check`）
+
+### 3. 動作確認
+- [x] ビルドが成功することを確認（`cargo build`）
+- [ ] 実際のRaindrop APIに対してget_collectionsを実行し、エラーが解消されることを確認
+
+### 4. 完了
+- [ ] 全てのタスクが完了したことを確認
+
+## 進捗メモ
+- 開始時刻: 2025-07-21
+- 関連issue: コレクション一覧取得時のfullNameフィールドエラー
+
+---
+
+# TODO: Fix i32 Field Null Error
+
+## タスクリスト
+
+### Phase 1: Collection構造体の修正
+- [x] `src/raindrop/types.rs`の`Collection`構造体の`sort`フィールドを`Option<i32>`に変更
+- [x] `src/raindrop/types.rs`の`Collection`構造体の`count`フィールドを`Option<i32>`に変更
+- [x] 既存のテストケースで`sort`と`count`を使用している箇所の修正
+
+### Phase 2: テスト
+- [x] `sort`と`count`フィールドがnullのコレクションのテストケースを追加
+- [x] 既存のユニットテストが全て通ることを確認（`cargo test`）
+- [x] linterチェック（`cargo clippy`）
+- [x] フォーマットチェック（`cargo fmt --check`）
+
+### Phase 3: 動作確認
+- [x] ビルドが成功することを確認（`cargo build`）
+- [ ] 実際のRaindrop APIに対してget_collectionsを実行し、エラーが解消されることを確認
+
+### Phase 4: 追加対応（必要に応じて）
+- [ ] AccessInfo構造体の`level`フィールドの修正（エラーが継続する場合）
+- [ ] Group構造体の`sort`フィールドの修正（エラーが継続する場合）
+
+### 完了
+- [ ] 全てのタスクが完了したことを確認
+
+## 進捗メモ
+- 開始時刻: 2025-07-21
+- 関連issue: コレクション一覧取得時のi32フィールドnullエラー
+
+---
+
+# TODO: Fix Important Field Serialization Error
+
+## タスクリスト
+
+### 1. コード修正
+- [x] `src/raindrop/types.rs`の`Bookmark`構造体の`important`フィールドを`Option<bool>`に変更
+- [x] 既存のテストケースで`important`を使用している箇所の修正
+
+### 2. テスト
+- [x] `important`フィールドが含まれないブックマークのテストケースを追加
+- [x] 既存のユニットテストが全て通ることを確認（`cargo test`）
+- [x] linterチェック（`cargo clippy`）
+- [x] フォーマットチェック（`cargo fmt --check`）
+
+### 3. 動作確認
+- [x] ビルドが成功することを確認（`cargo build`）
+- [ ] 実際のRaindrop APIに対してsearch_bookmarksを実行し、エラーが解消されることを確認
+
+### 4. 完了
+- [ ] 全てのタスクが完了したことを確認
+
+## 進捗メモ
+- 開始時刻: 2025-07-21
+- 関連issue: search_bookmarks実行時のimportantフィールドエラー

--- a/docs/fix-broken-field-error-plan.md
+++ b/docs/fix-broken-field-error-plan.md
@@ -1,0 +1,88 @@
+# Fix Plan: Broken Field Serialization Error
+
+## 問題の概要
+`get_bookmarks`ツールで「missing field 'broken' at line 1 column 1324」というJSONシリアライゼーションエラーが発生している。
+
+## 原因分析
+- `Bookmark`構造体の`broken`フィールドが`bool`型（必須フィールド）として定義されている（types.rs:195行目）
+- 実際のRaindrop APIレスポンスには`broken`フィールドが含まれていない場合がある
+- serdeのデシリアライゼーション時に必須フィールドが見つからないためエラーになる
+
+## 解決案の比較
+
+### 案1: `broken`フィールドをオプショナルにする ✅ (推奨)
+```rust
+pub broken: Option<bool>,
+```
+
+**メリット：**
+- APIレスポンスの実際の仕様に合わせた柔軟な対応
+- `broken`フィールドの有無を明示的に判断できる
+- 将来的なAPI変更にも柔軟に対応可能
+
+**デメリット：**
+- 既存のコードで`broken`フィールドを使用している箇所の修正が必要
+
+### 案2: デフォルト値を設定する
+```rust
+#[serde(default)]
+pub broken: bool,
+```
+
+**メリット：**
+- 既存のコードへの影響が最小限
+- 後方互換性を保ちやすい
+
+**デメリット：**
+- フィールドが存在しない場合は常に`false`となる
+- APIの実際の状態を正確に反映しない可能性
+
+## 採用する解決案
+**案1（オプショナル化）を採用します。**
+
+理由：
+1. Raindrop APIの実際の仕様に忠実
+2. `broken`フィールドの有無を明示的に判断でき、より正確なデータ表現が可能
+3. 将来的なAPI変更にも柔軟に対応可能
+4. エラーの根本原因を解決
+
+## 実装詳細
+
+### 1. 型定義の変更
+`src/raindrop/types.rs`の`Bookmark`構造体を修正：
+```rust
+// Before
+pub broken: bool,
+
+// After
+pub broken: Option<bool>,
+```
+
+### 2. テストケースの更新
+- types.rs:614行目: `"broken": false` → `"broken": false`（そのまま、Option型でも正しく動作）
+- types.rs:627行目: `assert!(!bookmark.broken);` → `assert_eq!(bookmark.broken, Some(false));`
+
+### 3. 影響範囲の確認
+`broken`フィールドを参照している箇所を確認し、必要に応じて修正：
+- 現在の実装では`broken`フィールドは読み取りのみで、直接操作していない
+- `ExportOptions`構造体にも`broken`フィールドがあるが、これは別の用途（フィルタリング）なので影響なし
+
+### 4. エラーハンドリングの改善
+デバッグのため、JSONデシリアライゼーションエラー時により詳細な情報を出力：
+```rust
+// client.rs:57行目付近
+serde_json::from_str::<T>(&text).map_err(|e| {
+    debug!("Failed to deserialize response: {}", e);
+    debug!("Response text: {}", text);
+    RaindropMcpError::JsonSerialization(e)
+})
+```
+
+## テスト計画
+1. 既存のユニットテストが全て通ることを確認
+2. `broken`フィールドが含まれないAPIレスポンスのテストケースを追加
+3. 実際のRaindrop APIに対してget_bookmarksを実行し、エラーが解消されることを確認
+
+## リスク評価
+- **低リスク**: `broken`フィールドは主に読み取り専用で使用されており、ビジネスロジックへの影響は最小限
+- 既存のAPIレスポンスで`broken`フィールドが含まれている場合も、Option型は正しく処理される

--- a/docs/fix-fullname-field-error-plan.md
+++ b/docs/fix-fullname-field-error-plan.md
@@ -1,0 +1,87 @@
+# Fix Plan: FullName Field Serialization Error
+
+## 問題の概要
+`get_collections`でコレクション一覧を取得する際に「missing field 'fullName' at line 1 column 244」というJSONシリアライゼーションエラーが発生している。
+
+## 原因分析
+- `CreatorRef`構造体の`full_name`フィールドが`String`型（必須フィールド）として定義されている（types.rs:152行目）
+- `Collection`構造体は`creator_ref: Option<CreatorRef>`を持つ（types.rs:113行目）
+- Raindrop APIレスポンスの`creatorRef`オブジェクトに`fullName`フィールドが含まれない場合がある
+- serdeのデシリアライゼーション時に必須フィールドが見つからないためエラーになる
+
+## 解決案
+`CreatorRef`構造体の`full_name`フィールドをオプショナルにする：
+
+```rust
+// Before
+pub full_name: String,
+
+// After  
+pub full_name: Option<String>,
+```
+
+## 実装詳細
+
+### 1. 型定義の変更
+`src/raindrop/types.rs`の`CreatorRef`構造体を修正：
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreatorRef {
+    #[serde(rename = "_id")]
+    pub id: i64,
+    pub full_name: Option<String>,  // String → Option<String>
+}
+```
+
+### 2. テストケースの更新
+- types.rs内の`CreatorRef`を使用しているテストの修正
+- 具体的には、テストケース内で`"fullName": "Creator Name"`を使用している箇所の動作確認
+
+### 3. 新しいテストケースの追加
+`fullName`フィールドが含まれない場合のテストケースを追加：
+```rust
+#[test]
+fn test_collection_without_creator_fullname() {
+    let json = json!({
+        "_id": 789,
+        "title": "Test Collection",
+        "view": "list",
+        "sort": 0,
+        "count": 0,
+        "user": { "$id": 123 },
+        "created": "2023-01-01T00:00:00Z",
+        "lastUpdate": "2023-01-01T00:00:00Z",
+        "creatorRef": {
+            "_id": 456
+            // Note: fullName field is intentionally omitted
+        }
+    });
+    
+    let collection: Collection = serde_json::from_value(json).unwrap();
+    assert_eq!(collection.id, 789);
+    assert!(collection.creator_ref.is_some());
+    assert_eq!(collection.creator_ref.unwrap().full_name, None);
+}
+```
+
+## 影響範囲
+- `CreatorRef`の`full_name`フィールドを参照している箇所：
+  - 現在の実装では直接参照されていない（テストケースのみ）
+  - APIレスポンスのデシリアライゼーションのみで使用
+
+## リスク評価
+- **低リスク**: 
+  - `CreatorRef`は主にAPIレスポンスのデシリアライゼーションで使用
+  - ビジネスロジックへの影響は最小限
+  - 既存のAPIレスポンスで`fullName`フィールドが含まれている場合も、Option型は正しく処理される
+
+## テスト計画
+1. 既存のユニットテストが全て通ることを確認
+2. `fullName`フィールドが含まれないコレクションのテストケースが成功することを確認
+3. linterとフォーマットチェックの実行
+4. 実際のRaindrop APIに対してget_collectionsを実行し、エラーが解消されることを確認
+
+## 関連情報
+- 前回の修正: `Bookmark`構造体の`broken`フィールドも同様の問題でOption型に変更済み
+- Raindrop APIの仕様では、一部のフィールドが省略可能である可能性が高い

--- a/docs/fix-i32-null-error-plan.md
+++ b/docs/fix-i32-null-error-plan.md
@@ -1,0 +1,129 @@
+# Fix Plan: i32 Field Null Error
+
+## 問題の概要
+`get_collections`で「invalid type: null, expected i32 at line 1 column 1489」というJSONシリアライゼーションエラーが発生している。
+
+## 原因分析
+Raindrop APIレスポンスで、i32型として定義されているフィールドにnull値が含まれている。
+
+調査の結果、以下のi32型フィールドがnullになる可能性がある：
+
+### 1. Collection構造体（最も可能性が高い）
+- `sort: i32` (types.rs:105行目) - コレクションの並び順
+- `count: i32` (types.rs:107行目) - コレクション内のアイテム数
+
+### 2. AccessInfo構造体
+- `level: i32` (types.rs:130行目) - アクセスレベル
+- Collection構造体の`access: Option<AccessInfo>`フィールド内
+
+### 3. Group構造体
+- `sort: i32` (types.rs:44行目) - グループの並び順
+- User構造体の`groups: Option<Vec<Group>>`フィールド内
+
+## 解決案
+
+### 段階的アプローチ
+エラー位置（column 1489）から判断して、Collection構造体のフィールドが最も疑わしいため、まずこれらを修正し、必要に応じて他のフィールドも対応する。
+
+### Phase 1: Collection構造体の修正
+```rust
+// Before
+pub sort: i32,
+pub count: i32,
+
+// After  
+pub sort: Option<i32>,
+pub count: Option<i32>,
+```
+
+### Phase 2: 必要に応じて追加修正
+Phase 1で解決しない場合：
+- `AccessInfo`の`level`フィールドをOption型に変更
+- `Group`の`sort`フィールドをOption型に変更
+
+## 実装詳細
+
+### 1. 型定義の変更
+`src/raindrop/types.rs`の`Collection`構造体を修正：
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Collection {
+    #[serde(rename = "_id")]
+    pub id: i64,
+    pub title: String,
+    pub description: Option<String>,
+    pub color: Option<String>,
+    pub public: Option<bool>,
+    pub view: CollectionView,
+    pub sort: Option<i32>,        // i32 → Option<i32>
+    pub cover: Option<Vec<String>>,
+    pub count: Option<i32>,        // i32 → Option<i32>
+    pub expanded: Option<bool>,
+    // ... rest of fields
+}
+```
+
+### 2. テストケースの更新
+既存のテストケースでsortとcountを使用している箇所：
+- `test_collection_deserialization` (types.rs:552行目付近)
+- 新しいコレクション作成時のデフォルト値設定
+
+### 3. 新しいテストケースの追加
+```rust
+#[test]
+fn test_collection_with_null_sort_and_count() {
+    let json = json!({
+        "_id": 999,
+        "title": "Test Collection with Nulls",
+        "view": "list",
+        "sort": null,
+        "count": null,
+        "user": { "$id": 123 },
+        "created": "2023-01-01T00:00:00Z",
+        "lastUpdate": "2023-01-01T00:00:00Z"
+    });
+    
+    let collection: Collection = serde_json::from_value(json).unwrap();
+    assert_eq!(collection.id, 999);
+    assert_eq!(collection.sort, None);
+    assert_eq!(collection.count, None);
+}
+```
+
+## 影響範囲の分析
+
+### ビジネスロジックへの影響
+1. **sort フィールド**
+   - コレクションの表示順序に使用される可能性
+   - デフォルト値として0を想定したロジックがある場合は要確認
+
+2. **count フィールド**
+   - コレクション内のアイテム数表示に使用
+   - UIでの表示やページネーション計算に影響する可能性
+
+### 対応が必要な箇所
+- sortやcountを直接参照している箇所でのnullチェック追加
+- デフォルト値の設定（例：`collection.sort.unwrap_or(0)`）
+
+## リスク評価
+- **中リスク**: 
+  - これらのフィールドはUIやソート機能で使用される重要なフィールド
+  - Option型への変更により、既存コードでのnullチェックが必要
+  - ただし、コンパイル時にエラーとして検出されるため、見落としのリスクは低い
+
+## テスト計画
+1. 既存のユニットテストが全て通ることを確認
+2. nullフィールドを含むコレクションのテストケースが成功することを確認
+3. 実際のRaindrop APIに対してget_collectionsを実行し、エラーが解消されることを確認
+4. sortとcountがnullの場合のUIでの表示を確認（必要に応じて）
+
+## デフォルト値の推奨
+- `sort`: 0（最初の位置）
+- `count`: 0（空のコレクション）
+
+使用例：
+```rust
+let sort_value = collection.sort.unwrap_or(0);
+let item_count = collection.count.unwrap_or(0);
+```

--- a/docs/fix-important-field-error-plan.md
+++ b/docs/fix-important-field-error-plan.md
@@ -1,0 +1,113 @@
+# Fix Plan: Important Field Serialization Error
+
+## 問題の概要
+`search_bookmarks`で「missing field 'important' at line 1 column 10408」というJSONシリアライゼーションエラーが発生している。
+
+## 原因分析
+- `Bookmark`構造体の`important`フィールドが`bool`型（必須フィールド）として定義されている（types.rs:192行目）
+- Raindrop APIレスポンスの一部のブックマークに`important`フィールドが含まれない場合がある
+- serdeのデシリアライゼーション時に必須フィールドが見つからないためエラーになる
+
+## 解決案
+`Bookmark`構造体の`important`フィールドをオプショナルにする：
+
+```rust
+// Before
+pub important: bool,
+
+// After  
+pub important: Option<bool>,
+```
+
+## 実装詳細
+
+### 1. 型定義の変更
+`src/raindrop/types.rs`の`Bookmark`構造体を修正：
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Bookmark {
+    // ... other fields
+    pub important: Option<bool>,  // bool → Option<bool>
+    // ... rest of fields
+}
+```
+
+### 2. テストケースの更新
+既存のテストケースで`important`を使用している箇所：
+- `test_bookmark_types` (types.rs:626行目付近) - `assert!(bookmark.important);`の修正
+
+### 3. 新しいテストケースの追加
+```rust
+#[test]
+fn test_bookmark_without_important_field() {
+    let json = json!({
+        "_id": 3003,
+        "title": "Test Bookmark Without Important",
+        "excerpt": "Testing optional important field",
+        "type": "link",
+        "tags": ["test"],
+        "link": "https://example.com/test",
+        "domain": "example.com",
+        "created": "2023-01-01T00:00:00Z",
+        "lastUpdate": "2023-01-02T00:00:00Z",
+        "media": [],
+        "user": { "$id": 123 },
+        "collection": { "$id": 456 },
+        // Note: 'important' field is intentionally omitted
+        "highlights": [],
+        "reminder": null,
+        "broken": false,
+        "cache": null
+    });
+    
+    let bookmark: Bookmark = serde_json::from_value(json).unwrap();
+    assert_eq!(bookmark.id, 3003);
+    assert_eq!(bookmark.important, None);
+}
+```
+
+## 影響範囲の分析
+
+### ビジネスロジックへの影響
+- **important フィールド**は重要なブックマークを示すフラグ
+- UIでの表示（星マークなど）や並び替えに使用される可能性
+- デフォルト値として`false`（重要でない）を想定することが妥当
+
+### APIエンドポイントへの影響
+- `create_bookmark`: `important`パラメータはすでにOption型として扱われている
+- `update_bookmark`: `important`パラメータはすでにOption型として扱われている
+- `search_bookmarks`: フィルタリング条件としての`important`もすでにOption型
+
+### 対応が必要な箇所
+- importantフィールドを直接参照している箇所でのnullチェック追加
+- デフォルト値の設定（例：`bookmark.important.unwrap_or(false)`）
+
+## リスク評価
+- **中リスク**: 
+  - UIでの重要マーク表示に影響する可能性
+  - 並び替えやフィルタリング機能への影響
+  - ただし、コンパイル時にエラーとして検出されるため、見落としのリスクは低い
+
+## テスト計画
+1. 既存のユニットテストが全て通ることを確認
+2. `important`フィールドが含まれないブックマークのテストケースが成功することを確認
+3. linterとフォーマットチェックの実行
+4. 実際のRaindrop APIに対してsearch_bookmarksを実行し、エラーが解消されることを確認
+
+## デフォルト値の推奨
+- `important`: `false`（重要でない）
+
+使用例：
+```rust
+let is_important = bookmark.important.unwrap_or(false);
+```
+
+## これまでの修正との整合性
+これまでに修正したフィールド：
+1. `Bookmark.broken`: `bool` → `Option<bool>`
+2. `CreatorRef.full_name`: `String` → `Option<String>`
+3. `Collection.sort`: `i32` → `Option<i32>`
+4. `Collection.count`: `i32` → `Option<i32>`
+
+今回の修正も同様のパターンで、Raindrop APIの仕様に合わせてオプショナルフィールドに変更する対応となります。

--- a/src/raindrop/client.rs
+++ b/src/raindrop/client.rs
@@ -54,7 +54,14 @@ impl RaindropClient {
         match status {
             StatusCode::OK | StatusCode::CREATED => {
                 let text = response.text().await?;
-                serde_json::from_str::<T>(&text).map_err(RaindropMcpError::JsonSerialization)
+                serde_json::from_str::<T>(&text).map_err(|e| {
+                    debug!("Failed to deserialize response: {}", e);
+                    debug!(
+                        "Response text (first 500 chars): {}",
+                        &text.chars().take(500).collect::<String>()
+                    );
+                    RaindropMcpError::JsonSerialization(e)
+                })
             }
             StatusCode::UNAUTHORIZED => Err(RaindropMcpError::Unauthorized(format!(
                 "Invalid or expired access token for {url}"

--- a/src/raindrop/types.rs
+++ b/src/raindrop/types.rs
@@ -102,9 +102,9 @@ pub struct Collection {
     pub color: Option<String>,
     pub public: Option<bool>,
     pub view: CollectionView,
-    pub sort: i32,
+    pub sort: Option<i32>,
     pub cover: Option<Vec<String>>,
-    pub count: i32,
+    pub count: Option<i32>,
     pub expanded: Option<bool>,
     pub parent: Option<ParentRef>,
     pub user: UserRef,
@@ -149,7 +149,7 @@ pub struct UserRef {
 pub struct CreatorRef {
     #[serde(rename = "_id")]
     pub id: i64,
-    pub full_name: String,
+    pub full_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -189,10 +189,10 @@ pub struct Bookmark {
     pub media: Option<Vec<Media>>,
     pub user: UserRef,
     pub collection: CollectionRef,
-    pub important: bool,
+    pub important: Option<bool>,
     pub highlights: Option<Vec<Highlight>>,
     pub reminder: Option<Reminder>,
-    pub broken: bool,
+    pub broken: Option<bool>,
     pub cache: Option<CacheInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file: Option<FileInfo>,
@@ -585,7 +585,8 @@ mod tests {
         let collection: Collection = serde_json::from_value(json).unwrap();
         assert_eq!(collection.id, 123);
         assert_eq!(collection.title, "My Collection");
-        assert_eq!(collection.count, 42);
+        assert_eq!(collection.sort, Some(123));
+        assert_eq!(collection.count, Some(42));
         assert!(collection.public.unwrap());
         assert!(collection.parent.is_some());
         assert_eq!(collection.parent.unwrap().id, 456);
@@ -623,9 +624,119 @@ mod tests {
         assert_eq!(bookmark.id, 1001);
         assert_eq!(bookmark.title, "Test Bookmark");
         assert_eq!(bookmark.tags.len(), 2);
-        assert!(bookmark.important);
-        assert!(!bookmark.broken);
+        assert_eq!(bookmark.important, Some(true));
+        assert_eq!(bookmark.broken, Some(false));
         matches!(bookmark.bookmark_type, BookmarkType::Link);
+    }
+
+    #[test]
+    fn test_bookmark_without_broken_field() {
+        // Test that bookmark can be deserialized even when 'broken' field is missing
+        let json = json!({
+            "_id": 2002,
+            "title": "Test Bookmark Without Broken",
+            "excerpt": "Testing optional broken field",
+            "note": "This bookmark has no broken field",
+            "type": "article",
+            "tags": ["test"],
+            "cover": null,
+            "link": "https://example.com/test",
+            "domain": "example.com",
+            "created": "2023-01-01T00:00:00Z",
+            "lastUpdate": "2023-01-02T00:00:00Z",
+            "media": [],
+            "user": { "$id": 123 },
+            "collection": { "$id": 456 },
+            "important": false,
+            "highlights": [],
+            "reminder": null,
+            // Note: 'broken' field is intentionally omitted
+            "cache": null
+        });
+
+        let bookmark: Bookmark = serde_json::from_value(json).unwrap();
+        assert_eq!(bookmark.id, 2002);
+        assert_eq!(bookmark.title, "Test Bookmark Without Broken");
+        assert_eq!(bookmark.broken, None); // Should be None when field is missing
+    }
+
+    #[test]
+    fn test_collection_without_creator_fullname() {
+        // Test that collection can be deserialized even when creator's fullName field is missing
+        let json = json!({
+            "_id": 789,
+            "title": "Test Collection",
+            "description": "A test collection without creator fullName",
+            "view": "list",
+            "sort": 0,
+            "count": 5,
+            "user": { "$id": 123 },
+            "created": "2023-01-01T00:00:00Z",
+            "lastUpdate": "2023-01-02T00:00:00Z",
+            "creatorRef": {
+                "_id": 456
+                // Note: fullName field is intentionally omitted
+            }
+        });
+
+        let collection: Collection = serde_json::from_value(json).unwrap();
+        assert_eq!(collection.id, 789);
+        assert_eq!(collection.title, "Test Collection");
+        assert!(collection.creator_ref.is_some());
+        let creator = collection.creator_ref.unwrap();
+        assert_eq!(creator.id, 456);
+        assert_eq!(creator.full_name, None); // Should be None when field is missing
+    }
+
+    #[test]
+    fn test_collection_with_null_sort_and_count() {
+        // Test that collection can be deserialized even when sort and count fields are null
+        let json = json!({
+            "_id": 999,
+            "title": "Test Collection with Nulls",
+            "description": "Testing null i32 fields",
+            "view": "list",
+            "sort": null,
+            "count": null,
+            "user": { "$id": 123 },
+            "created": "2023-01-01T00:00:00Z",
+            "lastUpdate": "2023-01-02T00:00:00Z"
+        });
+
+        let collection: Collection = serde_json::from_value(json).unwrap();
+        assert_eq!(collection.id, 999);
+        assert_eq!(collection.title, "Test Collection with Nulls");
+        assert_eq!(collection.sort, None);
+        assert_eq!(collection.count, None);
+    }
+
+    #[test]
+    fn test_bookmark_without_important_field() {
+        // Test that bookmark can be deserialized even when 'important' field is missing
+        let json = json!({
+            "_id": 3003,
+            "title": "Test Bookmark Without Important",
+            "excerpt": "Testing optional important field",
+            "type": "link",
+            "tags": ["test"],
+            "link": "https://example.com/test",
+            "domain": "example.com",
+            "created": "2023-01-01T00:00:00Z",
+            "lastUpdate": "2023-01-02T00:00:00Z",
+            "media": [],
+            "user": { "$id": 123 },
+            "collection": { "$id": 456 },
+            // Note: 'important' field is intentionally omitted
+            "highlights": [],
+            "reminder": null,
+            "broken": false,
+            "cache": null
+        });
+
+        let bookmark: Bookmark = serde_json::from_value(json).unwrap();
+        assert_eq!(bookmark.id, 3003);
+        assert_eq!(bookmark.title, "Test Bookmark Without Important");
+        assert_eq!(bookmark.important, None); // Should be None when field is missing
     }
 
     #[test]
@@ -680,9 +791,9 @@ mod tests {
             color: None,
             public: Some(false),
             view: CollectionView::List,
-            sort: 0,
+            sort: Some(0),
             cover: None,
-            count: 0,
+            count: Some(0),
             expanded: None,
             parent: None,
             user: UserRef { id: 456 },


### PR DESCRIPTION
- Changed Bookmark.broken from bool to Option<bool>
- Changed CreatorRef.full_name from String to Option<String>
- Changed Collection.sort and Collection.count from i32 to Option<i32>
- Changed Bookmark.important from bool to Option<bool>
- Added debug logging for deserialization errors
- Added test cases for missing/null fields

This fixes JSON deserialization errors when Raindrop API returns responses with missing or null fields for these properties.

🤖 Generated with [Claude Code](https://claude.ai/code)